### PR TITLE
Add VivaMap entry to resources list in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,6 +221,7 @@ Portals and data sources that provide access to Swiss Open Government Data.
 - [geospatial-data-catalogs](https://github.com/giswqs/geospatial-data-catalogs) - A list of open geospatial datasets available on AWS, Earth Engine, Planetary Computer, NASA CMR, and STAC Index.
 - [GeoBeer Switzerland](https://geobeer.ch/) - GeoBeerCH is an informal meeting of people interested in geography, GIS, cartography and the latest technologies.
 - [mapplus.ch](https://www.mapplus.ch/) - Various Geo Data portals, viewers and links.
+- [VivaMap](https://vivamap.ch/) - Data-driven map-based exploration for the best quality-of-life in Switzerland, ~3.2M H3 hexes, and ~2.5M building rooftops across dimensions (noise, air quality, transport, taxation, hazards, schools, etc.). Trilingual (FR/DE/EN); methodology and source list public. Large tax optimization section.
 
 ## Linked Open Data
 


### PR DESCRIPTION
Hi — proposing one new entry under `### Miscellaneous Geo Data`.

VivaMap (https://vivamap.ch) is a civic data tool that scores every Swiss
commune, ~3.2M H3 hexes, and ~2.5M individual building rooftops on nine
quality-of-life dimensions (noise, air quality, schools, public transport,
taxation, natural hazards, etc.) on a 0–10 scale. The output is a trilingual
(FR / DE / EN) interactive map plus per-commune SEO pages.

It is built end-to-end on Swiss open government data — primarily sources
already listed in this awesome list:

- swisstopo (national topo, swissBUILDINGS3D, hazard layers, noise rasters)
- BFS (statpop, GWR/RegBL, official commune register, taxation)
- BAFU / FOEN (air quality, biodiversity)
- MeteoSwiss (climate normals)
- opentransportdata.swiss (GTFS feeds)
- geo.admin.ch (federal cadastre + identify endpoint for live address
  resolution)
- OSM via Overpass (POIs, transport stops)

The full source list and licences are public at
https://vivamap.ch/en/sources, and the scoring methodology (9 dimensions,
weighting, three H3 resolutions, building inheritance) at
https://vivamap.ch/en/methodology — both pages exist in FR / DE / EN.

The site is statically exported, ships no third-party analytics, sets no
cookies, and respects the licences of every source it consumes (CC0, dl-de,
OpenData-CH, etc.). It is a fit for `Miscellaneous Geo Data` next to
GeoHarvester and mapplus.ch — both third-party projects aggregating Swiss
geo OGD.

Happy to shorten the entry, move it to a different section, or split the
methodology / sources links if that better matches the list's conventions.